### PR TITLE
Add failing test.

### DIFF
--- a/Zend/tests/autoloading/function/missing_function_in_namespace.phpt
+++ b/Zend/tests/autoloading/function/missing_function_in_namespace.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Missing function in namespace
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+namespace zoq {
+	quux();
+}
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Call to undefined function zoq\quux() in %s
+Stack trace:
+#0 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
Couldn't see an explicit one. Currently gets an error:

> Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 139835989824120 bytes) in
> /var/app/php_src/girgias_php_src/Zend/tests/autoloading/function/missing_function_in_namespace.php on line 6

Though only for certain letter counts in the function name....

btw there seem to quite a few similar failing tests in the other test directories.