### PR TITLE
Zend autoloader fallback once

### DIFF
--- a/Zend/tests/autoloading/function/global_fallback002.phpt
+++ b/Zend/tests/autoloading/function/global_fallback002.phpt
@@ -2,17 +2,23 @@
 Fallback to global function should not trigger autoloading.
 --FILE--
 <?php
+
 namespace {
     function loader($name) {
-        echo $name, \PHP_EOL;
+        echo "function loader called with $name\n";
     }
 
     autoload_register_function('loader');
+
+    function foo() {
+        echo "I am foo in global namespace.\n";
+    }
 }
 
 namespace bar {
-	var_dump('Hello');
+	foo();
 }
+
 ?>
 --EXPECT--
-string(5) "Hello"
+I am foo in global namespace.

--- a/Zend/tests/autoloading/function/global_fallback002.phpt
+++ b/Zend/tests/autoloading/function/global_fallback002.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Fallback to global function should not trigger autoloading.
+Fallback to global function triggers autoloading once.
 --FILE--
 <?php
 
@@ -21,4 +21,5 @@ namespace bar {
 
 ?>
 --EXPECT--
+function loader called with bar\foo
 I am foo in global namespace.

--- a/Zend/tests/autoloading/function/global_fallback003.phpt
+++ b/Zend/tests/autoloading/function/global_fallback003.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Fallback to non-existent function triggers autoloading once in namespace, once in global.
+--FILE--
+<?php
+
+namespace {
+    function loader($name) {
+        echo "function loader called with $name\n";
+    }
+
+    autoload_register_function('loader');
+}
+
+namespace bar {
+    try {
+        non_existent_function();
+    }
+    catch (\Error $e) {
+        echo "Error correctly caught: " . $e->getMessage() . "\n";
+    }
+}
+
+?>
+--EXPECT--
+function loader called with bar\non_existent_function
+function loader called with non_existent_function
+Error correctly caught: Call to undefined function bar\non_existent_function()

--- a/Zend/tests/autoloading/function/global_fallback_doesnt_repeat_autoloading.phpt
+++ b/Zend/tests/autoloading/function/global_fallback_doesnt_repeat_autoloading.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Fallback to global function should trigger autoloading only once per namespace.
+--FILE--
+<?php
+
+namespace {
+    function loader($name) {
+        echo "function loader called with $name\n";
+    }
+
+    autoload_register_function('loader');
+
+    function foo() {
+        echo "I am foo in global namespace.\n";
+    }
+}
+
+namespace bar {
+    foo();
+
+    for ($i = 0; $i < 3; $i += 1) {
+        foo();
+    }
+}
+namespace bar {
+    foo();
+}
+
+namespace Quux {
+    foo();
+}
+
+?>
+--EXPECT--
+function loader called with bar\foo
+I am foo in global namespace.
+I am foo in global namespace.
+I am foo in global namespace.
+I am foo in global namespace.
+I am foo in global namespace.
+function loader called with Quux\foo
+I am foo in global namespace.

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -3859,18 +3859,21 @@ ZEND_VM_HOT_HANDLER(69, ZEND_INIT_NS_FCALL_BY_NAME, ANY, CONST, NUM|CACHE_SLOT)
 	if (UNEXPECTED(fbc == NULL)) {
 		zval *function_name = (zval *)RT_CONSTANT(opline, opline->op2);
 		/* Fetch lowercase name stored in the next literal slot */
-		fbc = zend_lookup_function_ex(Z_STR_P(function_name), Z_STR_P(function_name+1), /* use_autoload */ false);
+		fbc = zend_lookup_function_ex(Z_STR_P(function_name), Z_STR_P(function_name+1), /* use_autoload */ true);
 		if (UNEXPECTED(fbc == NULL)) {
 			if (UNEXPECTED(EG(exception))) {
 				HANDLE_EXCEPTION();
 			}
 			/* Fallback onto global namespace, by fetching the unqualified lowercase name stored in the second literal slot */
-			fbc = zend_lookup_function_ex(Z_STR_P(function_name+2), Z_STR_P(function_name+2), /* use_autoload */ false);
+			fbc = zend_lookup_function_ex(Z_STR_P(function_name+2), Z_STR_P(function_name+2), /* use_autoload */ true);
 			if (fbc == NULL) {
 				if (UNEXPECTED(EG(exception))) {
 					HANDLE_EXCEPTION();
 				}
 				ZEND_VM_DISPATCH_TO_HELPER(zend_undefined_function_helper);
+			}
+			else {
+				do_bind_function(fbc, function_name);
 			}
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&fbc->op_array))) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -3764,18 +3764,21 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_NS_FCALL_BY_N
 	if (UNEXPECTED(fbc == NULL)) {
 		zval *function_name = (zval *)RT_CONSTANT(opline, opline->op2);
 		/* Fetch lowercase name stored in the next literal slot */
-		fbc = zend_lookup_function_ex(Z_STR_P(function_name), Z_STR_P(function_name+1), /* use_autoload */ false);
+		fbc = zend_lookup_function_ex(Z_STR_P(function_name), Z_STR_P(function_name+1), /* use_autoload */ true);
 		if (UNEXPECTED(fbc == NULL)) {
 			if (UNEXPECTED(EG(exception))) {
 				HANDLE_EXCEPTION();
 			}
 			/* Fallback onto global namespace, by fetching the unqualified lowercase name stored in the second literal slot */
-			fbc = zend_lookup_function_ex(Z_STR_P(function_name+2), Z_STR_P(function_name+2), /* use_autoload */ false);
+			fbc = zend_lookup_function_ex(Z_STR_P(function_name+2), Z_STR_P(function_name+2), /* use_autoload */ true);
 			if (fbc == NULL) {
 				if (UNEXPECTED(EG(exception))) {
 					HANDLE_EXCEPTION();
 				}
 				ZEND_VM_TAIL_CALL(zend_undefined_function_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
+			}
+			else {
+				do_bind_function(fbc, function_name);
 			}
 		}
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&fbc->op_array))) {


### PR DESCRIPTION
Bearing in mind I have no idea what I'm doing and am quite unsure about what is going to be in "slots"....

So when the fallback to global namespace happens in a namespace, that needs to block any future autoloading attempts in that namespace, both for performance reasons, and because of "it would be too nuts if the function that was actually called changed".

Is the change below at all sane? If not, is there a way of doing this?
