### PR TITLE
Add failing test for checking a string assignment from $_GET

### DIFF
--- a/ext/standard/tests/strings/literals/015.phpt
+++ b/ext/standard/tests/strings/literals/015.phpt
@@ -1,0 +1,13 @@
+--TEST--
+String assignment from $_GET in eval()
+--XFAIL--
+Any string from $_GET should not return true on an is_literal() check
+--FILE--
+$_GET['evil'] = 'hi';
+eval('$foo = "'.$_GET['evil'].'";');
+
+var_dump($foo);
+var_dump(is_literal($foo));
+--EXPECT--
+string(2) "hi"
+bool(false)


### PR DESCRIPTION
A string that is assigned from `$_GET` should not pass an `is_literal()` check.